### PR TITLE
fix: real Amazon Linux 2 distros have Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN yum makecache fast \
       sudo \
       which \
       python-pip \
+      python3 \
+      python3-pip
  && yum clean all
 
 # Install Ansible via Pip.


### PR DESCRIPTION
A stock Amazon Linux 2 AMI on AWS has Python3 installed at /usr/bin/python3, similar to Python 2 at /usr/bin/python. This PR sets this Molecule testing image to match that expectation. That being said, python3 isn't installed in the upstream `amazonlinux:*` docker image, so you may not want to do this.

I'm testing an Ansible role and have the `ansible_python_interpreter` in the inventory set to `/usr/bin/python3`. This works on the real servers I tested against but fails with this container because python3 isn't installed. I was working on a `prepare.yml` installation where I override the `ansible_python_interpreter` just for the converge and idempotence steps when I figured I'd file this PR to get the image aligned to real stock distro expectations and save myself the trouble.